### PR TITLE
Sync with fbcode: fix tabs/spaces mix & lint, add --thread_names option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(quickstack)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 include(CPack)
 
+set(CMAKE_CXX_STANDARD 11)
 set(SOURCE quickstack.cc)
 set(BINUTILS_LIB_DIR /usr/binutils/lib /usr/binutils/lib64)
 

--- a/quickstack.cc
+++ b/quickstack.cc
@@ -19,7 +19,7 @@
 #error "unsupported os"
 #endif
 
-const char *version = "0.10";
+const char* version = "0.10";
 int target_pid = 0;
 int debug_level = 2;
 int debug_print_time_level = 10;
@@ -28,26 +28,23 @@ int flush_log = 3;
 int timeout_seconds = 600;
 bool lock_all = false;
 
-const char *debug_dir = "/usr/lib/debug";
-int *_attach_started = 0;
+const char* debug_dir = "/usr/lib/debug";
+int* _attach_started = 0;
 stopper_symbol stopper[3] = {
-  {"main", 0, 0},
-  {"start_thread", 0, 0},
-  {"do_sigwait", 0, 0}
-};
+    {"main", 0, 0}, {"start_thread", 0, 0}, {"do_sigwait", 0, 0}};
 int num_stopper_symbol = 3;
-string basic_libs[10] = {
-  "ld-",
-  "libaio.",
-  "libc-",
-  "libm-",
-  "libdl-",
-  "libpthread-",
-  "librt-",
-  "libgcc_",
-  "libcrypt-",
-  "libnss_" "libnsl_" "libstdc++"
-};
+string basic_libs[10] = {"ld-",
+                         "libaio.",
+                         "libc-",
+                         "libm-",
+                         "libdl-",
+                         "libpthread-",
+                         "librt-",
+                         "libgcc_",
+                         "libcrypt-",
+                         "libnss_"
+                         "libnsl_"
+                         "libstdc++"};
 int num_basic_libs = 10;
 volatile sig_atomic_t shutdown_program = 0;
 int print_arg = 0;
@@ -56,33 +53,26 @@ int trace_multiple_procs = 0;
 int basename_only = 0;
 int max_ptrace_calls = 1000;
 int max_frame_size = 16384 * sizeof(long);
-const char *stack_out;
-FILE *stack_out_fp;
+const char* stack_out;
+FILE* stack_out_fp;
 
+static void set_shutdown(int) { shutdown_program = 1; }
 
-static void set_shutdown(int)
-{
-  shutdown_program = 1;
-}
-
-static void init_signals()
-{
-  int signals[] = { SIGHUP, SIGINT, SIGTERM };
+static void init_signals() {
+  int signals[] = {SIGHUP, SIGINT, SIGTERM};
   for (uint i = 0; i < sizeof(signals) / sizeof(int); i++)
     signal(signals[i], set_shutdown);
   return;
 }
 
-static void ignore_signals()
-{
-  int signals[] = { SIGHUP, SIGINT, SIGTERM };
+static void ignore_signals() {
+  int signals[] = {SIGHUP, SIGINT, SIGTERM};
   for (uint i = 0; i < sizeof(signals) / sizeof(int); i++)
     signal(signals[i], SIG_IGN);
   return;
 }
 
-void print_log(int level, const char *format, ...)
-{
+void print_log(int level, const char* format, ...) {
   if (level < debug_print_time_level) {
     struct timeval tv;
     time_t tt;
@@ -90,9 +80,15 @@ void print_log(int level, const char *format, ...)
     gettimeofday(&tv, 0);
     tt = tv.tv_sec;
     tm = localtime(&tt);
-    fprintf(stdout, "%04d-%02d-%02d %02d:%02d:%02d %06ld: ",
-	    tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
-	    tm->tm_min, tm->tm_sec, tv.tv_usec);
+    fprintf(stdout,
+            "%04d-%02d-%02d %02d:%02d:%02d %06ld: ",
+            tm->tm_year + 1900,
+            tm->tm_mon + 1,
+            tm->tm_mday,
+            tm->tm_hour,
+            tm->tm_min,
+            tm->tm_sec,
+            tv.tv_usec);
   } else {
     fprintf(stdout, "                            ");
   }
@@ -106,8 +102,7 @@ void print_log(int level, const char *format, ...)
     fflush(stdout);
 }
 
-void print_stack(const char *format, ...)
-{
+void print_stack(const char* format, ...) {
   va_list args;
   va_start(args, format);
   if (stack_out_fp) {
@@ -120,18 +115,15 @@ void print_stack(const char *format, ...)
   va_end(args);
 }
 
-static string dirname(const string & path)
-{
+static string dirname(const string& path) {
   return path.substr(0, path.find_last_of('/'));
 }
 
-static string basename(const string & path)
-{
+static string basename(const string& path) {
   return path.substr(path.find_last_of('/') + 1);
 }
 
-static bool startwith(const string & fullstring, const string & starting)
-{
+static bool startwith(const string& fullstring, const string& starting) {
   if (fullstring.length() >= starting.length()) {
     if (!fullstring.compare(0, starting.length(), starting))
       return true;
@@ -141,33 +133,32 @@ static bool startwith(const string & fullstring, const string & starting)
   return false;
 }
 
-static bool endwith(const string & fullstring, const string & ending)
-{
+static bool endwith(const string& fullstring, const string& ending) {
   if (fullstring.length() >= ending.length()) {
     return (0 ==
-	    fullstring.compare(fullstring.length() - ending.length(),
-			       ending.length(), ending));
+            fullstring.compare(fullstring.length() - ending.length(),
+                               ending.length(),
+                               ending));
   } else {
     return false;
   }
   return false;
 }
 
-static int is_pid_stopped(int pid)
-{
-  FILE *status_file;
+static int is_pid_stopped(int pid) {
+  FILE* status_file;
   char buf[100];
   int retval = 0;
 
-  snprintf(buf, sizeof(buf), "/proc/%d/status", (int) pid);
+  snprintf(buf, sizeof(buf), "/proc/%d/status", (int)pid);
   status_file = fopen(buf, "r");
   if (status_file != NULL) {
     int have_state = 0;
     while (fgets(buf, sizeof(buf), status_file)) {
       buf[strlen(buf) - 1] = '\0';
       if (strncmp(buf, "State:", 6) == 0) {
-	have_state = 1;
-	break;
+        have_state = 1;
+        break;
       }
     }
     if (have_state && strstr(buf, "T") != NULL) {
@@ -179,8 +170,7 @@ static int is_pid_stopped(int pid)
   return retval;
 }
 
-static bool match_debug_file(const string & name, const char *file)
-{
+static bool match_debug_file(const string& name, const char* file) {
   string ptr = file;
   string ending = ".debug";
 
@@ -195,7 +185,7 @@ static bool match_debug_file(const string & name, const char *file)
   if (!endwith(ptr, ending))
     return false;
   ptr = ptr.substr(0, ptr.length() - ending.length());
-  char *work = (char *) ptr.c_str();
+  char* work = (char*)ptr.c_str();
   while (*work) {
     if ((*work >= 0 && *work <= 9) || *work == '.')
       work++;
@@ -205,15 +195,14 @@ static bool match_debug_file(const string & name, const char *file)
   return true;
 }
 
-static int get_user_regs(int pid, user_regs_struct & regs)
-{
+static int get_user_regs(int pid, user_regs_struct& regs) {
   int count = 100;
   while (1) {
     int e = ptrace(PTRACE_GETREGS, pid, 0, &regs);
     if (e != 0) {
       if (errno == ESRCH && count-- > 0) {
-	sched_yield();
-	continue;
+        sched_yield();
+        continue;
       }
       perror("ptrace(PTRACE_GETREGS)");
       return -1;
@@ -223,8 +212,7 @@ static int get_user_regs(int pid, user_regs_struct & regs)
   return 0;
 }
 
-static char *find_debug_file(const char *stripped_file)
-{
+static char* find_debug_file(const char* stripped_file) {
   string path;
   path = debug_dir;
   path += stripped_file;
@@ -232,59 +220,52 @@ static char *find_debug_file(const char *stripped_file)
   string name = basename(path);
 
   string real_debug_file;
-  DIR *dp = opendir(dirname1.c_str());
+  DIR* dp = opendir(dirname1.c_str());
   if (dp) {
-    struct dirent *dent;
+    struct dirent* dent;
     do {
       dent = readdir(dp);
       if (dent) {
-	if (dent->d_name[0] == '.')
-	  continue;
-	if (match_debug_file(name, dent->d_name)) {
-	  real_debug_file = dirname1;
-	  real_debug_file += "/";
-	  real_debug_file += dent->d_name;
-	  break;
-	}
+        if (dent->d_name[0] == '.')
+          continue;
+        if (match_debug_file(name, dent->d_name)) {
+          real_debug_file = dirname1;
+          real_debug_file += "/";
+          real_debug_file += dent->d_name;
+          break;
+        }
       }
-    }
-    while (dent);
+    } while (dent);
     closedir(dp);
   }
   return strdup(real_debug_file.c_str());
 }
 
-
-void bfd_handle::free_syms_if()
-{
+void bfd_handle::free_syms_if() {
   if (syms != NULL) {
     free(syms);
     syms = NULL;
   }
 }
 
-void bfd_handle::free_st_if()
-{
+void bfd_handle::free_st_if() {
   if (st != NULL) {
     delete st;
     st = NULL;
   }
 }
 
-bool bfd_handle::has_debug()
-{
-  return has_debug_symbols;
+bool bfd_handle::has_debug() { return has_debug_symbols; }
+
+int bfd_handle::get_file_line(ulong addr,
+                              const char** file,
+                              const char** function,
+                              uint* lineno) {
+  return bfd_find_nearest_line(
+      abfd, dbgsec, syms, addr - 1, file, function, lineno);
 }
 
-int bfd_handle::get_file_line(ulong addr, const char **file,
-			      const char **function, uint * lineno)
-{
-  return bfd_find_nearest_line(abfd, dbgsec, syms, addr - 1, file,
-			       function, lineno);
-}
-
-void bfd_handle::close_all()
-{
+void bfd_handle::close_all() {
   free_st_if();
   free_syms_if();
   close();
@@ -292,8 +273,7 @@ void bfd_handle::close_all()
     free(debug_file);
 }
 
-void bfd_handle::init(const char *file = NULL)
-{
+void bfd_handle::init(const char* file = NULL) {
   abfd = bfd_openr(file ? file : filename, NULL);
   if (!abfd) {
     fprintf(stderr, "Failed at bfd_openr! %s\n", file ? file : filename);
@@ -303,75 +283,69 @@ void bfd_handle::init(const char *file = NULL)
   assert((bfd_get_file_flags(abfd) & HAS_SYMS) != 0);
 }
 
-void bfd_handle::debug_init()
-{
+void bfd_handle::debug_init() {
   close();
   init(debug_file);
 }
 
-bfd *bfd_handle::get()
-{
-  return abfd;
-}
+bfd* bfd_handle::get() { return abfd; }
 
-void bfd_handle::close()
-{
+void bfd_handle::close() {
   if (abfd)
     bfd_close(abfd);
   abfd = NULL;
 }
 
-void
-load_stopper_symbols(symbol_table * sorted_st, bool relative,
-		     ulong addr_begin)
-{
+void load_stopper_symbols(symbol_table* sorted_st,
+                          bool relative,
+                          ulong addr_begin) {
   int matched_stopper = -1;
-  for (symbol_table::symbols_type::iterator i =
-       sorted_st->symbols.begin(); i != sorted_st->symbols.end(); i++) {
+  for (symbol_table::symbols_type::iterator i = sorted_st->symbols.begin();
+       i != sorted_st->symbols.end();
+       i++) {
     int j = 0;
     if (matched_stopper >= 0) {
       stopper[matched_stopper].addr_end = i->addr;
       if (relative) {
-	stopper[matched_stopper].addr_end += addr_begin;
+        stopper[matched_stopper].addr_end += addr_begin;
       }
       matched_stopper = -1;
     }
     for (j = 0; j < num_stopper_symbol; j++) {
       if (stopper[j].name == i->name) {
-	stopper[j].addr_begin = i->addr;
-	if (relative) {
-	  stopper[j].addr_begin += addr_begin;
-	}
-	matched_stopper = j;
+        stopper[j].addr_begin = i->addr;
+        if (relative) {
+          stopper[j].addr_begin += addr_begin;
+        }
+        matched_stopper = j;
       }
     }
   }
 }
 
-void bfd_handle::load_symbols(bool relative, ulong addr_begin)
-{
+void bfd_handle::load_symbols(bool relative, ulong addr_begin) {
   st = new symbol_table();
   load_debug_section_if();
-  asection *const text_sec = bfd_get_section_by_name(abfd, ".text");
+  asection* const text_sec = bfd_get_section_by_name(abfd, ".text");
   if (text_sec) {
     st->text_vma = text_sec->vma;
     st->text_size = text_sec->size;
   }
 
-  symcnt = bfd_read_minisymbols(abfd, 0, (void **) &syms, &size);
+  symcnt = bfd_read_minisymbols(abfd, 0, (void**)&syms, &size);
   if (!symcnt) {
     free_syms_if();
-    symcnt = bfd_read_minisymbols(abfd, 1, (void **) &syms, &size);
+    symcnt = bfd_read_minisymbols(abfd, 1, (void**)&syms, &size);
     dynamic = 1;
   }
 
-  asymbol *store = bfd_make_empty_symbol(abfd);
+  asymbol* store = bfd_make_empty_symbol(abfd);
   assert(store);
 
-  bfd_byte *p = (bfd_byte *) syms;
-  bfd_byte *pend = p + symcnt * size;
+  bfd_byte* p = (bfd_byte*)syms;
+  bfd_byte* pend = p + symcnt * size;
   for (; p < pend; p += size) {
-    asymbol *sym = 0;
+    asymbol* sym = 0;
     sym = bfd_minisymbol_to_symbol(abfd, dynamic, p, store);
     if ((sym->flags & BSF_FUNCTION) == 0) {
       continue;
@@ -379,11 +353,10 @@ void bfd_handle::load_symbols(bool relative, ulong addr_begin)
     symbol_info sinfo;
     bfd_get_symbol_info(abfd, sym, &sinfo);
     if (sinfo.type != 'T' && sinfo.type != 't' && sinfo.type != 'W' &&
-	sinfo.type != 'w') {
+        sinfo.type != 'w') {
       continue;
     }
-    DBG(40, "%s %lx f=%x", sinfo.name, (long) sinfo.value,
-	(int) sym->flags);
+    DBG(40, "%s %lx f=%x", sinfo.name, (long)sinfo.value, (int)sym->flags);
 
     if (startwith(sinfo.name, "__tcf"))
       continue;
@@ -395,19 +368,16 @@ void bfd_handle::load_symbols(bool relative, ulong addr_begin)
     e.name = string(sinfo.name);
     st->symbols.push_back(e);
   }
-  std::sort(st->symbols.begin(), st->symbols.end(),
-	    std::less < ulong > ());
+  std::sort(st->symbols.begin(), st->symbols.end(), std::less<ulong>());
   load_stopper_symbols(st, relative, addr_begin);
 }
 
-void bfd_handle::load_debug_section_if()
-{
+void bfd_handle::load_debug_section_if() {
   dbgsec = bfd_get_section_by_name(abfd, ".debug_info");
   if (!dbgsec) {
     debug_file = find_debug_file(filename);
     if (debug_file && strlen(debug_file) > 0) {
-      DBG(3, "Reading debug file %s, original(%s) ..", debug_file,
-	  filename);
+      DBG(3, "Reading debug file %s, original(%s) ..", debug_file, filename);
       debug_init();
       dbgsec = bfd_get_section_by_name(abfd, ".debug_info");
     }
@@ -421,31 +391,30 @@ void bfd_handle::load_debug_section_if()
   }
 }
 
-static bool check_shlib(const std::string & fn)
-{
+static bool check_shlib(const std::string& fn) {
   auto_fp fp(fopen(fn.c_str(), "r"));
   if (fp == 0) {
     return false;
   }
   elf_version(EV_CURRENT);
-  Elf *elf = elf_begin(fileno(fp), ELF_C_READ, NULL);
+  Elf* elf = elf_begin(fileno(fp), ELF_C_READ, NULL);
   if (elf == 0) {
     return false;
   }
   ulong vaddr = 0;
 #if defined(__i386__)
-  Elf32_Ehdr *const ehdr = elf32_getehdr(elf);
-  Elf32_Phdr *const phdr = elf32_getphdr(elf);
+  Elf32_Ehdr* const ehdr = elf32_getehdr(elf);
+  Elf32_Phdr* const phdr = elf32_getphdr(elf);
 #else
-  Elf64_Ehdr *const ehdr = elf64_getehdr(elf);
-  Elf64_Phdr *const phdr = elf64_getphdr(elf);
+  Elf64_Ehdr* const ehdr = elf64_getehdr(elf);
+  Elf64_Phdr* const phdr = elf64_getphdr(elf);
 #endif
   const int num_phdr = ehdr->e_phnum;
   for (int i = 0; i < num_phdr; ++i) {
 #if defined(__i386__)
-    Elf32_Phdr *const p = phdr + i;
+    Elf32_Phdr* const p = phdr + i;
 #else
-    Elf64_Phdr *const p = phdr + i;
+    Elf64_Phdr* const p = phdr + i;
 #endif
     if (p->p_type == PT_LOAD && (p->p_flags & 1) != 0) {
       vaddr = p->p_vaddr;
@@ -456,17 +425,15 @@ static bool check_shlib(const std::string & fn)
   return vaddr == 0;
 }
 
-static bool file_exists(const char *filename)
-{
-  if (FILE * file = fopen(filename, "r")) {
+static bool file_exists(const char* filename) {
+  if (FILE* file = fopen(filename, "r")) {
     fclose(file);
     return true;
   }
   return false;
 }
 
-static bool has_exec_permission(const char *filename)
-{
+static bool has_exec_permission(const char* filename) {
   struct stat results;
   stat(filename, &results);
   if (results.st_mode & S_IXUSR)
@@ -474,35 +441,35 @@ static bool has_exec_permission(const char *filename)
   return false;
 }
 
-static void
-read_proc_map_ent(char *line, proc_info & pinfo, symbol_table_map * stmap)
-{
+static void read_proc_map_ent(char* line,
+                              proc_info& pinfo,
+                              symbol_table_map* stmap) {
   bool delete_marked = false;
-  char *t1 = strchr(line, ' ');
+  char* t1 = strchr(line, ' ');
   if (!t1) {
     return;
   }
-  char *t2 = strchr(t1 + 1, ' ');
+  char* t2 = strchr(t1 + 1, ' ');
   if (!t2) {
     return;
   }
-  char *t3 = strchr(t2 + 1, ' ');
+  char* t3 = strchr(t2 + 1, ' ');
   if (!t3) {
     return;
   }
-  char *t4 = strchr(t3 + 1, ' ');
+  char* t4 = strchr(t3 + 1, ' ');
   if (!t4) {
     return;
   }
-  char *t5 = strchr(t4 + 1, ' ');
+  char* t5 = strchr(t4 + 1, ' ');
   if (!t5) {
     return;
   }
   while (t5[1] == ' ') {
     ++t5;
   }
-  char *t6 = strchr(t5 + 1, '\n');
-  char *t7 = strchr(t5 + 1, ' ');
+  char* t6 = strchr(t5 + 1, '\n');
+  char* t7 = strchr(t5 + 1, ' ');
   if (!t6) {
     return;
   }
@@ -539,8 +506,7 @@ read_proc_map_ent(char *line, proc_info & pinfo, symbol_table_map * stmap)
     e.stbl = stmap->get(e.path.c_str());
     e.relative = check_shlib(e.path);
     if (!e.stbl) {
-      bfd_handle *bh = NULL;
-      bh = new bfd_handle(e.path.c_str());
+      bfd_handle* bh = new bfd_handle(e.path.c_str());
       bh->init();
       bh->load_symbols(e.relative, e.addr_begin);
       stmap->set(e.path.c_str(), bh->st);
@@ -548,14 +514,15 @@ read_proc_map_ent(char *line, proc_info & pinfo, symbol_table_map * stmap)
       e.stbl->bh = bh;
     }
   }
-  DBG(10, "%s: relative=%d addr_begin=%016lx",
-      e.path.c_str(), (int) e.relative, e.addr_begin);
+  DBG(10,
+      "%s: relative=%d addr_begin=%016lx",
+      e.path.c_str(),
+      (int)e.relative,
+      e.addr_begin);
   pinfo.maps.push_back(e);
 }
 
-static void
-read_proc_maps(int pid, proc_info & pinfo, symbol_table_map * stmap)
-{
+static void read_proc_maps(int pid, proc_info& pinfo, symbol_table_map* stmap) {
   char fn[PATH_MAX];
   char buf[4096];
   snprintf(fn, sizeof(fn), "/proc/%d/maps", pid);
@@ -566,17 +533,18 @@ read_proc_maps(int pid, proc_info & pinfo, symbol_table_map * stmap)
   while (fgets(buf, sizeof(buf), fp) != 0) {
     read_proc_map_ent(buf, pinfo, stmap);
   }
-  std::sort(pinfo.maps.begin(), pinfo.maps.end(), std::less < ulong > ());
+  std::sort(pinfo.maps.begin(), pinfo.maps.end(), std::less<ulong>());
 }
 
-static const symbol_ent *find_symbol(const symbol_table * st,
-				     ulong addr, bool & is_text_r,
-				     ulong & pos_r, ulong & offset_r)
-{
+static const symbol_ent* find_symbol(const symbol_table* st,
+                                     ulong addr,
+                                     bool& is_text_r,
+                                     ulong& pos_r,
+                                     ulong& offset_r) {
   is_text_r = false;
   pos_r = 0;
   offset_r = 0;
-  const symbol_table::symbols_type & ss = st->symbols;
+  const symbol_table::symbols_type& ss = st->symbols;
   symbol_table::symbols_type::const_iterator j =
       std::upper_bound(ss.begin(), ss.end(), addr);
   if (j != ss.begin()) {
@@ -593,8 +561,7 @@ static const symbol_ent *find_symbol(const symbol_table * st,
   return &*j;
 }
 
-static bool match_basic_lib(const string & path)
-{
+static bool match_basic_lib(const string& path) {
   for (int i = 0; i < num_basic_libs; i++) {
     if (startwith(basename(path), basic_libs[i])) {
       return true;
@@ -603,8 +570,7 @@ static bool match_basic_lib(const string & path)
   return false;
 }
 
-static int pinfo_symbol_exists(const proc_info & pinfo, ulong addr)
-{
+static int pinfo_symbol_exists(const proc_info& pinfo, ulong addr) {
   /* 0: not exists, 1: core library, 2: others */
   int symbol_type = 0;
   proc_info::maps_type::const_iterator i =
@@ -617,8 +583,11 @@ static int pinfo_symbol_exists(const proc_info & pinfo, ulong addr)
   if (i == pinfo.maps.end()) {
     DBG(30, "%lx not found", addr);
   } else if (addr >= i->addr_begin + i->addr_size) {
-    DBG(30, "%lx out of range [%lx %lx]", addr, i->addr_begin,
-	i->addr_begin + i->addr_size);
+    DBG(30,
+        "%lx out of range [%lx %lx]",
+        addr,
+        i->addr_begin,
+        i->addr_begin + i->addr_size);
   } else if (!i->stbl || !i->stbl->bh) {
     DBG(30, "%lx no symbol found", addr);
   } else {
@@ -631,12 +600,12 @@ static int pinfo_symbol_exists(const proc_info & pinfo, ulong addr)
   return symbol_type;
 }
 
-static const symbol_ent *pinfo_find_symbol(const proc_info & pinfo,
-					   ulong addr, ulong & offset_r,
-					   bfd_handle ** bh_ptr,
-					   ulong & relative_addr,
-					   bool ignore_basic_libs = false)
-{
+static const symbol_ent* pinfo_find_symbol(const proc_info& pinfo,
+                                           ulong addr,
+                                           ulong& offset_r,
+                                           bfd_handle** bh_ptr,
+                                           ulong& relative_addr,
+                                           bool ignore_basic_libs = false) {
   offset_r = 0;
   proc_info::maps_type::const_iterator i =
       std::upper_bound(pinfo.maps.begin(), pinfo.maps.end(), addr);
@@ -648,8 +617,11 @@ static const symbol_ent *pinfo_find_symbol(const proc_info & pinfo,
   if (i == pinfo.maps.end()) {
     DBG(30, "%lx not found", addr);
   } else if (addr >= i->addr_begin + i->addr_size) {
-    DBG(30, "%lx out of range [%lx %lx]", addr, i->addr_begin,
-	i->addr_begin + i->addr_size);
+    DBG(30,
+        "%lx out of range [%lx %lx]",
+        addr,
+        i->addr_begin,
+        i->addr_begin + i->addr_size);
   } else if (!i->stbl || !i->stbl->bh) {
     DBG(30, "%lx no symbol found", addr);
     if (i->is_vdso) {
@@ -658,8 +630,8 @@ static const symbol_ent *pinfo_find_symbol(const proc_info & pinfo,
   } else {
     if (ignore_basic_libs) {
       if (match_basic_lib(i->path)) {
-	DBG(10, "Matched basic libs2 %s", i->path.c_str());
-	return 0;
+        DBG(10, "Matched basic libs2 %s", i->path.c_str());
+        return 0;
       }
     }
     ulong a = addr;
@@ -670,8 +642,7 @@ static const symbol_ent *pinfo_find_symbol(const proc_info & pinfo,
     ulong pos = 0;
     ulong offset = 0;
     bool is_text = false;
-    const symbol_ent *const e =
-	find_symbol(i->stbl, a, is_text, pos, offset);
+    const symbol_ent* const e = find_symbol(i->stbl, a, is_text, pos, offset);
     *bh_ptr = i->stbl->bh;
     if (e != 0 && is_text) {
       offset_r = offset;
@@ -682,8 +653,7 @@ static const symbol_ent *pinfo_find_symbol(const proc_info & pinfo,
   return 0;
 }
 
-static bool is_stopper_addr(ulong addr)
-{
+static bool is_stopper_addr(ulong addr) {
   bool is_stopper = false;
   int i;
   for (i = 0; i < num_stopper_symbol; i++) {
@@ -695,12 +665,11 @@ static bool is_stopper_addr(ulong addr)
   return is_stopper;
 }
 
-
-static int
-get_stack_trace(int pid, proc_info & pinfo, uint maxlen,
-		const user_regs_struct & regs,
-		std::vector < ulong > &vals_r)
-{
+static int get_stack_trace(int pid,
+                           proc_info& pinfo,
+                           uint maxlen,
+                           const user_regs_struct& regs,
+                           std::vector<ulong>& vals_r) {
   uint i = 0;
   // candidate for the next stack address
   ulong next_likely_sp = 0;
@@ -756,15 +725,17 @@ get_stack_trace(int pid, proc_info & pinfo, uint maxlen,
     }
 
     if (retaddr == top_sp) {
-      DBG(10, "Addr matched top sp %016lx. "
-	  "Dropping previously scanned blocks.", retaddr);
+      DBG(10,
+          "Addr matched top sp %016lx. "
+          "Dropping previously scanned blocks.",
+          retaddr);
       matched_top_sp = true;
       if (n_frames >= 2) {
-	vals_r.clear();
-	vals_r.push_back(top_addr);
-	n_scanned_from_last_frame = 0;
-	n_frames = 1;
-	sp_jumped = false;
+        vals_r.clear();
+        vals_r.push_back(top_addr);
+        n_scanned_from_last_frame = 0;
+        n_frames = 1;
+        sp_jumped = false;
       }
     }
     if (pinfo.maps.empty()) {
@@ -775,96 +746,100 @@ get_stack_trace(int pid, proc_info & pinfo, uint maxlen,
 
     if (symbol_type) {
       error_count = 0;
-      if (frame_check && symbol_type == 2 &&
-	  n_scanned_from_last_frame >= 3 &&
-	  ((!matched_top_sp && n_scanned_from_last_frame >= 10) ||
-	   n_frames >= 2 || top_addr_is_user_func) && !next_likely_sp) {
-	DBG(10, "Non target addr %016lx", retaddr);
+      if (frame_check && symbol_type == 2 && n_scanned_from_last_frame >= 3 &&
+          ((!matched_top_sp && n_scanned_from_last_frame >= 10) ||
+           n_frames >= 2 || top_addr_is_user_func) &&
+          !next_likely_sp) {
+        DBG(10, "Non target addr %016lx", retaddr);
       } else {
-	if (next_likely_sp) {
-	  DBG(10, "Jumping to next likely sp %016lx", next_likely_sp);
-	  rollback_addr = sp - sizeof(long);
-	  sp_jumped = true;
-	  sp = next_likely_sp;
-	}
-	n_frames++;
-	n_scanned_from_last_frame = 0;
-	DBG(10, "Pushed addr %016lx", retaddr);
-	vals_r.push_back(retaddr);
-	next_likely_sp = 0;
-	if (n_frames == 2 && !second_addr) {
-	  DBG(10, " This is second frame addr.");
-	  second_addr = retaddr;
-	}
+        if (next_likely_sp) {
+          DBG(10, "Jumping to next likely sp %016lx", next_likely_sp);
+          rollback_addr = sp - sizeof(long);
+          sp_jumped = true;
+          sp = next_likely_sp;
+        }
+        n_frames++;
+        n_scanned_from_last_frame = 0;
+        DBG(10, "Pushed addr %016lx", retaddr);
+        vals_r.push_back(retaddr);
+        next_likely_sp = 0;
+        if (n_frames == 2 && !second_addr) {
+          DBG(10, " This is second frame addr.");
+          second_addr = retaddr;
+        }
       }
     } else {
       error_count++;
       if (retaddr >= sp + sizeof(long) && retaddr < sp + max_frame_size) {
-	DBG(10, "retaddr is in sp range", "");
-	error_count = 0;
+        DBG(10, "retaddr is in sp range", "");
+        error_count = 0;
       } else if (frame_check && error_count >= 2) {
-	next_likely_sp = 0;
-	if (rollback_addr && sp_jumped) {
-	  DBG(10, "Previous next likely sp was invalid."
-	      "Scanning from %016lx", rollback_addr);
-	  sp = rollback_addr;
-	  rollback_addr = 0;
-	  //n_scanned= n_scanned - error_count;
-	  error_count = 0;
-	  sp_jumped = false;
-	  if (!matched_top_sp || n_frames >= 2) {
-	    vals_r.clear();
-	    vals_r.push_back(top_addr);
-	    n_scanned_from_last_frame = 0;
-	  }
-	  n_frames = 1;
-	  continue;
-	}
+        next_likely_sp = 0;
+        if (rollback_addr && sp_jumped) {
+          DBG(10,
+              "Previous next likely sp was invalid."
+              "Scanning from %016lx",
+              rollback_addr);
+          sp = rollback_addr;
+          rollback_addr = 0;
+          // n_scanned= n_scanned - error_count;
+          error_count = 0;
+          sp_jumped = false;
+          if (!matched_top_sp || n_frames >= 2) {
+            vals_r.clear();
+            vals_r.push_back(top_addr);
+            n_scanned_from_last_frame = 0;
+          }
+          n_frames = 1;
+          continue;
+        }
       }
     }
     if (is_stopper_addr(retaddr)) {
       DBG(3, "Matched stopper func.", 0);
       if (vals_r.size() == 2 && second_addr && second_addr != retaddr) {
-	DBG(10, "Putting second_addr.");
-	vals_r.pop_back();
-	vals_r.push_back(second_addr);
-	vals_r.push_back(retaddr);
+        DBG(10, "Putting second_addr.");
+        vals_r.pop_back();
+        vals_r.push_back(second_addr);
+        vals_r.push_back(retaddr);
       }
       break;
     }
     bool do_rollback = false;
     if (retaddr >= sp + sizeof(long) && retaddr < sp + max_frame_size) {
       if (next_likely_sp && n_frames <= 2) {
-	DBG(10, "Finding Next Likely sp consecutive times. "
-	    "Previously pushed addr was invalid");
-	do_rollback = true;
+        DBG(10,
+            "Finding Next Likely sp consecutive times. "
+            "Previously pushed addr was invalid");
+        do_rollback = true;
       }
       next_likely_sp = retaddr;
       if (retaddr > sp + sizeof(long)) {
-	sp_jumped = true;
+        sp_jumped = true;
       } else {
-	sp_jumped = false;
+        sp_jumped = false;
       }
       DBG(10, "Next Likely SP: %016lx", next_likely_sp);
     }
     if (sp_jumped && frame_check) {
       if (n_scanned_from_last_frame >= 5 && n_frames >= 3) {
-	DBG(10,
-	    "Scanned %d blocks from the last frame. This is invalid.",
-	    n_scanned_from_last_frame);
-	do_rollback = true;
-      } else if (symbol_type == 1 && n_frames >= 3
-		 && !is_stopper_addr(retaddr)) {
-	DBG(10,
-	    "Matched core lib symbol type in the middle of stack frames. This is invalid.");
-	do_rollback = true;
+        DBG(10,
+            "Scanned %d blocks from the last frame. This is invalid.",
+            n_scanned_from_last_frame);
+        do_rollback = true;
+      } else if (symbol_type == 1 && n_frames >= 3 &&
+                 !is_stopper_addr(retaddr)) {
+        DBG(10,
+            "Matched core lib symbol type in the middle of stack frames. "
+            "This is invalid.");
+        do_rollback = true;
       }
     }
     if (do_rollback) {
       if (rollback_addr) {
-	DBG(10, "Scanning from %016lx", rollback_addr);
-	sp = rollback_addr;
-	rollback_addr = 0;
+        DBG(10, "Scanning from %016lx", rollback_addr);
+        sp = rollback_addr;
+        rollback_addr = 0;
       }
       vals_r.clear();
       vals_r.push_back(top_addr);
@@ -877,26 +852,24 @@ get_stack_trace(int pid, proc_info & pinfo, uint maxlen,
   return 0;
 }
 
-char *get_demangled_symbol(const char *symbol_name)
-{
-  char *demangled = NULL;
+char* get_demangled_symbol(const char* symbol_name) {
   uint arg = DMGL_ANSI;
   if (print_arg) {
     arg |= DMGL_PARAMS;
     arg |= DMGL_TYPES;
   }
-  demangled = cplus_demangle(symbol_name, arg);
+  char* demangled = cplus_demangle(symbol_name, arg);
   if (!demangled) {
     demangled = strdup(symbol_name);
   }
   return demangled;
 }
 
-void
-parse_stack_trace(const int pid, const proc_info & pinfo,
-		  const user_regs_struct & regs,
-		  const std::vector < ulong > &vals_sps, size_t maxlen)
-{
+void parse_stack_trace(const int pid,
+                       const proc_info& pinfo,
+                       const user_regs_struct& regs,
+                       const std::vector<ulong>& vals_sps,
+                       size_t maxlen) {
   char buf[128];
   uint rank = 1;
   std::string rstr;
@@ -908,62 +881,61 @@ parse_stack_trace(const int pid, const proc_info & pinfo,
     ulong addr = vals_sps[i];
     ulong rel_addr = 0;
     ulong offset = 0;
-    char *demangled;
-    bfd_handle *bh;
+    char* demangled;
+    bfd_handle* bh;
     DBG(11, "addr: %016lx %ld %ld", addr, vals_sps.size(), maxlen);
     bool ignore_basic_libs = true;
     if (i == 0 || i == std::min(vals_sps.size(), maxlen) - 1) {
       ignore_basic_libs = false;
     }
-    const symbol_ent *e = pinfo_find_symbol(pinfo,
-					    addr, offset, &bh, rel_addr,
-					    ignore_basic_libs);
+    const symbol_ent* e = pinfo_find_symbol(
+        pinfo, addr, offset, &bh, rel_addr, ignore_basic_libs);
     if (e != 0) {
       if (offset != 0) {
-	if (!single_line) {
-	  sprintf(buf, "#%02d  ", rank++);
-	  out << buf;
-	  sprintf(buf, "0x%016lx", addr);
-	  out << buf;
-	  out << " in ";
-	  demangled = get_demangled_symbol(e->name.c_str());
-	  out << demangled;
-	  free(demangled);
-	  if (!print_arg) {
-	    out << " ()";
-	  }
-	  if (bh->has_debug()) {
-	    int ret;
-	    ret = bh->get_file_line(rel_addr ? rel_addr : addr,
-				    &file, &name, &lineno);
-	    if (ret && file) {
-	      if (basename_only) {
-		file = basename(file);
-	      }
-	      out << " from ";
-	      out << file;
-	      out << ":";
-	      out << lineno;
-	      out << "";
-	    }
-	  } else {
-	    if (basename_only) {
-	      file = basename(bh->filename);
-	    } else {
-	      file = bh->filename;
-	    }
-	    out << " from ";
-	    out << file;
-	  }
-	  print_stack("%s\n", out.str().c_str());
-	} else {
-	  if (!rstr.empty()) {
-	    rstr += ":";
-	  }
-	  demangled = get_demangled_symbol(e->name.c_str());
-	  rstr += demangled;
-	  free(demangled);
-	}
+        if (!single_line) {
+          snprintf(buf, sizeof(buf), "#%02d  ", rank++);
+          out << buf;
+          snprintf(buf, sizeof(buf), "0x%016lx", addr);
+          out << buf;
+          out << " in ";
+          demangled = get_demangled_symbol(e->name.c_str());
+          out << demangled;
+          free(demangled);
+          if (!print_arg) {
+            out << " ()";
+          }
+          if (bh->has_debug()) {
+            int ret;
+            ret = bh->get_file_line(
+                rel_addr ? rel_addr : addr, &file, &name, &lineno);
+            if (ret && file) {
+              if (basename_only) {
+                file = basename(file);
+              }
+              out << " from ";
+              out << file;
+              out << ":";
+              out << lineno;
+              out << "";
+            }
+          } else {
+            if (basename_only) {
+              file = basename(bh->filename);
+            } else {
+              file = bh->filename;
+            }
+            out << " from ";
+            out << file;
+          }
+          print_stack("%s\n", out.str().c_str());
+        } else {
+          if (!rstr.empty()) {
+            rstr += ":";
+          }
+          demangled = get_demangled_symbol(e->name.c_str());
+          rstr += demangled;
+          free(demangled);
+        }
       }
     }
   }
@@ -972,9 +944,7 @@ parse_stack_trace(const int pid, const proc_info & pinfo,
   }
 }
 
-
-static int ptrace_attach_proc(int pid)
-{
+static int ptrace_attach_proc(int pid) {
   if (ptrace(PTRACE_ATTACH, pid, 0, 0) != 0) {
     if (errno == ESRCH) {
       DBG(11, "No such process: %d", pid);
@@ -993,8 +963,7 @@ static int ptrace_attach_proc(int pid)
   return 0;
 }
 
-static int ptrace_detach_proc(int pid)
-{
+static int ptrace_detach_proc(int pid) {
   if (ptrace(PTRACE_DETACH, pid, 0, 0) != 0) {
     perror("ptrace(PTRACE_DETACH)");
     return -1;
@@ -1002,8 +971,7 @@ static int ptrace_detach_proc(int pid)
   return 0;
 }
 
-int get_tgid(int target_pid)
-{
+int get_tgid(int target_pid) {
   int tgid = -1;
   char fn[PATH_MAX];
   char buf[4096];
@@ -1020,44 +988,41 @@ int get_tgid(int target_pid)
   return tgid;
 }
 
-void get_pids(int target_pid, std::vector < int >&pids_r)
-{
+void get_pids(int target_pid, std::vector<int>& pids_r) {
   char fn[PATH_MAX];
   bool target_pid_exists = false;
   snprintf(fn, sizeof(fn), "/proc/%d/task", target_pid);
-  DIR *dp = opendir(fn);
+  DIR* dp = opendir(fn);
   int tgid = get_tgid(target_pid);
   if (tgid <= 0) {
     fprintf(stderr, "Failed to get parent's process id!\n");
     exit(1);
   }
   if (dp) {
-    struct dirent *dent;
+    struct dirent* dent;
     do {
       dent = readdir(dp);
       if (dent) {
-	if (dent->d_name[0] == '.')
-	  continue;
-	int pid = atoi(dent->d_name);
-	if (pid == target_pid) {
-	  target_pid_exists = true;
-	  continue;
-	} else if (tgid != target_pid) {
-	  continue;
-	} else {
-	  pids_r.push_back(pid);
-	}
+        if (dent->d_name[0] == '.')
+          continue;
+        int pid = atoi(dent->d_name);
+        if (pid == target_pid) {
+          target_pid_exists = true;
+          continue;
+        } else if (tgid != target_pid) {
+          continue;
+        } else {
+          pids_r.push_back(pid);
+        }
       }
-    }
-    while (dent);
+    } while (dent);
     closedir(dp);
   } else {
     fprintf(stderr, "Failed to access directory %s\n", fn);
     exit(1);
   }
   if (!target_pid_exists) {
-    fprintf(stderr, "Process id %d does not exist on %s\n", target_pid,
-	    fn);
+    fprintf(stderr, "Process id %d does not exist on %s\n", target_pid, fn);
     exit(1);
   }
   std::sort(pids_r.begin(), pids_r.end());
@@ -1065,14 +1030,12 @@ void get_pids(int target_pid, std::vector < int >&pids_r)
   return;
 }
 
-static double timediff(struct timeval tv0, struct timeval tv1)
-{
+static double timediff(struct timeval tv0, struct timeval tv1) {
   return (tv1.tv_sec - tv0.tv_sec) * 1e+3 +
-      (double) ((double) tv1.tv_usec * 1e-3 - (double) tv0.tv_usec * 1e-3);
+         (double)((double)tv1.tv_usec * 1e-3 - (double)tv0.tv_usec * 1e-3);
 }
 
-void print_trace_report(proc_info * pinfos, const vector < int >&pids)
-{
+void print_trace_report(proc_info* pinfos, const vector<int>& pids) {
   int slowest_pid = 0;
   double slowest_time = -1;
   double sum_time = 0;
@@ -1086,28 +1049,33 @@ void print_trace_report(proc_info * pinfos, const vector < int >&pids)
   }
   // Traced time == hangup time
   DBG(1, "Total Traced Time: %6.3f milliseconds", sum_time);
-  DBG(1, "Average Traced Time Per LWP: %6.3f milliseconds",
-      (double) sum_time / pids.size());
-  DBG(1, "Longest Traced LWP: LWP %d, %6.3f milliseconds",
-      slowest_pid, slowest_time);
+  DBG(1,
+      "Average Traced Time Per LWP: %6.3f milliseconds",
+      (double)sum_time / pids.size());
+  DBG(1,
+      "Longest Traced LWP: LWP %d, %6.3f milliseconds",
+      slowest_pid,
+      slowest_time);
 }
 
-void
-attach_and_dump_all(const vector < int >&pids, proc_info * pinfos,
-		    vector < ulong > *vals_sps, user_regs_struct * regs,
-		    bool * fails, bool lock_main)
-{
+void attach_and_dump_all(const vector<int>& pids,
+                         proc_info* pinfos,
+                         vector<ulong>* vals_sps,
+                         user_regs_struct* regs,
+                         bool* fails,
+                         bool lock_main) {
   for (size_t i = 0; i < pids.size(); ++i) {
 
     if (lock_main && pids[i] == target_pid) {
       if (get_user_regs(pids[i], regs[i]) != 0) {
-	fails[i] = true;
+        fails[i] = true;
       } else {
-	if (max_ptrace_calls &&
-	    get_stack_trace(pids[i], pinfos[i],
-			    max_ptrace_calls, regs[i], vals_sps[i]) != 0) {
-	  fails[i] = true;
-	}
+        if (max_ptrace_calls &&
+            get_stack_trace(
+                pids[i], pinfos[i], max_ptrace_calls, regs[i], vals_sps[i]) !=
+                0) {
+          fails[i] = true;
+        }
       }
       continue;
     }
@@ -1129,23 +1097,26 @@ attach_and_dump_all(const vector < int >&pids, proc_info * pinfos,
       fails[i] = true;
     } else {
       if (get_user_regs(pids[i], regs[i]) != 0) {
-	fails[i] = true;
+        fails[i] = true;
       } else {
-	if (max_ptrace_calls &&
-	    get_stack_trace(pids[i], pinfos[i],
-			    max_ptrace_calls, regs[i], vals_sps[i]) != 0) {
-	  fails[i] = true;
-	}
+        if (max_ptrace_calls &&
+            get_stack_trace(
+                pids[i], pinfos[i], max_ptrace_calls, regs[i], vals_sps[i]) !=
+                0) {
+          fails[i] = true;
+        }
       }
     }
     if (rc != ESRCH) {
       ptrace_detach_proc(pids[i]);
       gettimeofday(&pinfos[i].tv_end, 0);
-      pinfos[i].stall_time =
-	  timediff(pinfos[i].tv_start, pinfos[i].tv_end);
+      pinfos[i].stall_time = timediff(pinfos[i].tv_start, pinfos[i].tv_end);
       DBG(3, "Detached process %d", pids[i]);
-      DBG(3, "Tracing duration at LWP %d was "
-	  "%7.3f milliseconds\n", pids[i], pinfos[i].stall_time);
+      DBG(3,
+          "Tracing duration at LWP %d was "
+          "%7.3f milliseconds\n",
+          pids[i],
+          pinfos[i].stall_time);
     }
     if (shutdown_program) {
       DBG(1, "Got termination signal");
@@ -1154,11 +1125,11 @@ attach_and_dump_all(const vector < int >&pids, proc_info * pinfos,
   }
 }
 
-void
-attach_and_dump_lock_all(const vector < int >&pids, proc_info * pinfos,
-			 vector < ulong > *vals_sps,
-			 user_regs_struct * regs, bool * fails)
-{
+void attach_and_dump_lock_all(const vector<int>& pids,
+                              proc_info* pinfos,
+                              vector<ulong>* vals_sps,
+                              user_regs_struct* regs,
+                              bool* fails) {
   struct timeval tv_start, tv_end;
   DBG(1, "Attaching main process %d, locking all.", target_pid);
   gettimeofday(&tv_start, 0);
@@ -1173,19 +1144,20 @@ attach_and_dump_lock_all(const vector < int >&pids, proc_info * pinfos,
   ptrace_detach_proc(target_pid);
   gettimeofday(&tv_end, 0);
   DBG(1, "Detached main process %d", target_pid);
-  DBG(3, "Tracing duration at main process %d was "
-      "%7.3f milliseconds\n", target_pid, timediff(tv_start, tv_end));
+  DBG(3,
+      "Tracing duration at main process %d was "
+      "%7.3f milliseconds\n",
+      target_pid,
+      timediff(tv_start, tv_end));
 }
 
-
-void dump_stack(const vector < int >&pids)
-{
+void dump_stack(const vector<int>& pids) {
   uint trace_length = 1000;
-  symbol_table_map *stmap = new symbol_table_map();
-  proc_info *pinfos = new proc_info[pids.size()];
-  vector < ulong > *vals_sps = new vector < ulong >[pids.size()];
-  user_regs_struct *regs = new user_regs_struct[pids.size()];
-  bool *fails = new bool[pids.size()];
+  symbol_table_map* stmap = new symbol_table_map();
+  proc_info* pinfos = new proc_info[pids.size()];
+  vector<ulong>* vals_sps = new vector<ulong>[pids.size()];
+  user_regs_struct* regs = new user_regs_struct[pids.size()];
+  bool* fails = new bool[pids.size()];
 
   DBG(1, "Reading process symbols..");
   for (size_t i = 0; i < pids.size(); ++i) {
@@ -1197,9 +1169,10 @@ void dump_stack(const vector < int >&pids)
   }
 
   if (is_pid_stopped(target_pid)) {
-    DBG(1, "Target PID %d stops. Consider starting "
-	"the process with kill -CONT. Exiting without tracing.",
-	target_pid);
+    DBG(1,
+        "Target PID %d stops. Consider starting "
+        "the process with kill -CONT. Exiting without tracing.",
+        target_pid);
     exit(1);
   }
   DBG(1, "Gathering stack traces..");
@@ -1220,58 +1193,51 @@ void dump_stack(const vector < int >&pids)
   for (size_t i = 0; i < pids.size(); ++i) {
     if (fails[i] == false) {
       if (single_line) {
-	print_stack("%d  ", pids[i]);
+        print_stack("%d  ", pids[i]);
       } else {
-	print_stack("\nThread %ld (LWP %d):\n", pids.size() - i, pids[i]);
+        print_stack("\nThread %ld (LWP %d):\n", pids.size() - i, pids[i]);
       }
-      parse_stack_trace(pids[i], pinfos[i],
-			regs[i], vals_sps[i], trace_length);
+      parse_stack_trace(pids[i], pinfos[i], regs[i], vals_sps[i], trace_length);
     }
   }
   if (stack_out_fp) {
     fclose(stack_out_fp);
     stack_out_fp = NULL;
   }
-  delete[]fails;
-  delete[]pinfos;
-  delete[]vals_sps;
-  delete[]regs;
+  delete[] fails;
+  delete[] pinfos;
+  delete[] vals_sps;
+  delete[] regs;
   delete stmap;
 }
 
 struct option long_options[] = {
-  {"?", no_argument, 0, '?'},
-  {"help", no_argument, 0, 'h'},
-  {"version", no_argument, 0, 'v'},
-  {"arg_print", no_argument, 0, 'a'},
-  {"basename_only", no_argument, 0, 'b'},
-  {"debug", required_argument, 0, 'd'},
-  {"debug_print_time_level", required_argument, 0, 't'},
-  {"pid", required_argument, 0, 'p'},
-  {"single_line", no_argument, 0, 's'},
-  {"calls", required_argument, 0, 'c'},
-  {"frame_check", no_argument, 0, 'f'},
-  {"stack_out", required_argument, 0, 'o'},
-  {"multiple_targets", required_argument, 0, 'm'},
-  {"flush_log", required_argument, 0, 'w'},
-  {"timeout_seconds", required_argument, 0, 'k'},
-  {"lock_all", no_argument, 0, 'l'},
-  {0, 0, 0, 0}
-};
+    {"?", no_argument, 0, '?'},
+    {"help", no_argument, 0, 'h'},
+    {"version", no_argument, 0, 'v'},
+    {"arg_print", no_argument, 0, 'a'},
+    {"basename_only", no_argument, 0, 'b'},
+    {"debug", required_argument, 0, 'd'},
+    {"debug_print_time_level", required_argument, 0, 't'},
+    {"pid", required_argument, 0, 'p'},
+    {"single_line", no_argument, 0, 's'},
+    {"calls", required_argument, 0, 'c'},
+    {"frame_check", no_argument, 0, 'f'},
+    {"stack_out", required_argument, 0, 'o'},
+    {"multiple_targets", required_argument, 0, 'm'},
+    {"flush_log", required_argument, 0, 'w'},
+    {"timeout_seconds", required_argument, 0, 'k'},
+    {"lock_all", no_argument, 0, 'l'},
+    {0, 0, 0, 0}};
 
-static void show_version()
-{
-  printf("quickstack version %s\n", version);
-}
+static void show_version() { printf("quickstack version %s\n", version); }
 
-static void version_exit()
-{
+static void version_exit() {
   show_version();
   exit(1);
 }
 
-static void usage_exit()
-{
+static void usage_exit() {
   show_version();
   printf("Usage: \n");
   printf(" quickstack [OPTIONS]\n\n");
@@ -1280,34 +1246,48 @@ static void usage_exit()
   printf("Options (short name):\n");
   printf(" -p, --pid=N                    :Target process id\n");
   printf(" -d, --debug=N                  :Debug level\n");
-  printf
-      (" -s, --single_line              :Printing call stack info into one line per process, instead of gdb-like output\n");
-  printf
-      (" -c, --calls=N                  :Maximum ptrace call counts per process. Default is 1000\n");
-  printf
-      (" -b, --basename_only            :Suppressing printing directory name of the target source files, but printing basename only. This makes easier for reading.\n");
-  printf
-      (" -f, --frame_check              :Checking frame pointers on non-standard libraries.\n");
-  printf
-      (" -o, --stack_out=f              :Writing stack traces to this file. Default is STDOUT.\n");
-  printf
-      (" -t, --debug_print_time_level=N :Suppressing printing timestamp if debug level is higher than N. This is for performance reason and default level (10) should be fine in most of cases.\n");
-  printf
-      (" -f, --multipe_targets=[0|1]    :Set 1 if tracing multiple different processes at one time\n");
-  printf
-      (" -w, --flush_log=N              :Flushing every log output if log level is equal or under N\n");
-  printf
-      (" -k, --timeout_seconds=N        :Terminates quickstack if exceeding N seconds. Default is 600 seconds\n");
-  printf
-      (" -l, --lock_all                 :Locking main process (given by --pid) during parsing all other processes. This will lock the whole process during taking all stack traces, so stall time is slightly increased, but will give more accurate results.\n");
+  printf(
+      " -s, --single_line              :Printing call stack info into one line "
+      "per process, instead of gdb-like output\n");
+  printf(
+      " -c, --calls=N                  :Maximum ptrace call counts per "
+      "process. Default is 1000\n");
+  printf(
+      " -b, --basename_only            :Suppressing printing directory name of "
+      "the target source files, but printing basename only. This makes easier "
+      "for reading.\n");
+  printf(
+      " -f, --frame_check              :Checking frame pointers on "
+      "non-standard libraries.\n");
+  printf(
+      " -o, --stack_out=f              :Writing stack traces to this file. "
+      "Default is STDOUT.\n");
+  printf(
+      " -t, --debug_print_time_level=N :Suppressing printing timestamp if "
+      "debug level is higher than N. This is for performance reason and "
+      "default level (10) should be fine in most of cases.\n");
+  printf(
+      " -f, --multipe_targets=[0|1]    :Set 1 if tracing multiple different "
+      "processes at one time\n");
+  printf(
+      " -w, --flush_log=N              :Flushing every log output if log level "
+      "is equal or under N\n");
+  printf(
+      " -k, --timeout_seconds=N        :Terminates quickstack if exceeding N "
+      "seconds. Default is 600 seconds\n");
+  printf(
+      " -l, --lock_all                 :Locking main process (given by --pid) "
+      "during parsing all other processes. This will lock the whole process "
+      "during taking all stack traces, so stall time is slightly increased, "
+      "but will give more accurate results.\n");
   exit(1);
 }
 
-static void get_options(int argc, char **argv)
-{
+static void get_options(int argc, char** argv) {
   int c, opt_ind = 0;
-  while ((c = getopt_long(argc, argv, "?absflvw:k:d:c:t:p:o:",
-			  long_options, &opt_ind)) != EOF) {
+  while ((c = getopt_long(
+              argc, argv, "?absflvw:k:d:c:t:p:o:", long_options, &opt_ind)) !=
+         EOF) {
     switch (c) {
     case '?':
       usage_exit();
@@ -1368,13 +1348,14 @@ static void get_options(int argc, char **argv)
 
 /* Sending SIGCONT if target pid is stopped. Since signal is sent in async,
  * we may retry a few times to verify if the target is really started. */
-int cont_process_if(int pid)
-{
+int cont_process_if(int pid) {
   int retry = 10;
   bool is_stopped = false;
   while ((is_stopped = is_pid_stopped(pid)) && retry-- > 0) {
-    DBG(1, "pid %d is stopped. Sending SIGCONT.. (remaining %d times)",
-	target_pid, retry);
+    DBG(1,
+        "pid %d is stopped. Sending SIGCONT.. (remaining %d times)",
+        target_pid,
+        retry);
     int rc = kill(pid, SIGCONT);
     if (rc == ESRCH)
       return 0;
@@ -1392,14 +1373,13 @@ int cont_process_if(int pid)
  * not aborted and target_pid (main pid) is running, we don't check
  * other processes. Otherwise we check all pids (including all LWPs of
  * the target process). */
-int cont_all_process(int main_pid, const vector < int >&pids, bool aborted)
-{
+int cont_all_process(int main_pid, const vector<int>& pids, bool aborted) {
   int status = 0;
   status = cont_process_if(main_pid);
   if (status <= 0 && !aborted)
     return status;
   DBG(1, "Needs cleanup. Sending SIGCONT to all processes if needed..")
-      for (size_t i = 0; i < pids.size(); ++i) {
+  for (size_t i = 0; i < pids.size(); ++i) {
     int rc = cont_process_if(pids[i]);
     if (rc)
       status = rc;
@@ -1409,10 +1389,8 @@ int cont_all_process(int main_pid, const vector < int >&pids, bool aborted)
   return status;
 }
 
-
-int main(int argc, char **argv)
-{
-  vector < int >pids;
+int main(int argc, char** argv) {
+  vector<int> pids;
   if (argc <= 1) {
     usage_exit();
   }
@@ -1421,9 +1399,8 @@ int main(int argc, char **argv)
   gettimeofday(&t_begin, 0);
   get_options(argc, argv);
   get_pids(target_pid, pids);
-  _attach_started = (int *) mmap(0, PAGE_SIZE,
-				 PROT_READ | PROT_WRITE,
-				 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  _attach_started = (int*)mmap(
+      0, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
   pid_t quickstack_core_pid = fork();
   if (quickstack_core_pid < 0) {
@@ -1447,7 +1424,7 @@ int main(int argc, char **argv)
     exited_pid = waitpid(quickstack_core_pid, &status, WNOHANG);
     if (exited_pid == -1) {
       if (errno == EINTR) {
-	continue;
+        continue;
       }
       DBG(1, "Got error on waitpid: %d", exited_pid);
     } else if (exited_pid == 0) {
@@ -1455,17 +1432,17 @@ int main(int argc, char **argv)
       sleep(1);
       gettimeofday(&t_current, 0);
       if (t_current.tv_sec >= t_begin.tv_sec + timeout_seconds) {
-	DBG(1, "Timeout %d seconds reached. Killing quickstack..",
-	    timeout_seconds);
-	kill(quickstack_core_pid, SIGKILL);
-	sleep(1);
+        DBG(1,
+            "Timeout %d seconds reached. Killing quickstack..",
+            timeout_seconds);
+        kill(quickstack_core_pid, SIGKILL);
+        sleep(1);
       }
     } else {
       /* quickstack ended */
       break;
     }
-  }
-  while (exited_pid == 0);
+  } while (exited_pid == 0);
 
   exit_code = WEXITSTATUS(status);
   if (exit_code) {
@@ -1481,8 +1458,9 @@ int main(int argc, char **argv)
   if (*_attach_started) {
     int stop_status = cont_all_process(target_pid, pids, cleanup_needed);
     if (stop_status) {
-      DBG(1, "FATAL: SIGCONT target process failed."
-	  " Target process remains state T.");
+      DBG(1,
+          "FATAL: SIGCONT target process failed."
+          " Target process remains state T.");
       exit(1);
     }
   }

--- a/quickstack.h
+++ b/quickstack.h
@@ -51,9 +51,13 @@ struct bfd_handle;
 struct symbol_ent {
   ulong addr;
   string name;
-  operator ulong() const { return addr; }
-  symbol_ent() : addr(0) {}
+  symbol_ent(const ulong addr = 0, const string& name = "")
+      : addr(addr), name(name) {}
 };
+
+inline bool operator<(const symbol_ent& lhs, const symbol_ent& rhs) {
+  return lhs.addr < rhs.addr;
+}
 
 struct symbol_table {
   typedef vector<symbol_ent> symbols_type;
@@ -153,15 +157,19 @@ struct proc_map_ent {
   symbol_table* stbl;
   bool relative : 1;
   bool is_vdso : 1;
-  operator ulong() const { return addr_begin; } /* for comparison */
-  proc_map_ent()
-      : addr_begin(0),
+
+  proc_map_ent(const ulong addr_begin = 0)
+      : addr_begin(addr_begin),
         addr_size(0),
         offset(0),
-        stbl(0),
+        stbl(nullptr),
         relative(false),
         is_vdso(false) {}
 };
+
+inline bool operator<(const proc_map_ent& lhs, const proc_map_ent& rhs) {
+  return lhs.addr_begin < rhs.addr_begin;
+}
 
 struct proc_info {
   typedef vector<proc_map_ent> maps_type;

--- a/quickstack.h
+++ b/quickstack.h
@@ -32,137 +32,139 @@ using std::vector;
 using std::map;
 
 // From binutils/include/demangle.h
-#define DMGL_PARAMS      (1 << 0)	/* Include function args */
-#define DMGL_ANSI        (1 << 1)	/* Include const, volatile, etc */
-#define DMGL_VERBOSE     (1 << 3)	/* Include implementation details.  */
-#define DMGL_TYPES       (1 << 4)	/* Also try to demangle type encodings. */
-extern "C" char *cplus_demangle(const char *mangled, int options);
+#define DMGL_PARAMS (1 << 0) /* Include function args */
+#define DMGL_ANSI (1 << 1) /* Include const, volatile, etc */
+#define DMGL_VERBOSE (1 << 3) /* Include implementation details.  */
+#define DMGL_TYPES (1 << 4) /* Also try to demangle type encodings. */
+extern "C" char* cplus_demangle(const char* mangled, int options);
 
-#define DBG(v, format, ...) if(debug_level >= v) { print_log(v, format, ##__VA_ARGS__); }
+#define DBG(v, format, ...)              \
+  if (debug_level >= v) {                \
+    print_log(v, format, ##__VA_ARGS__); \
+  }
 
-
-void print_log(int level, const char *format, ...);
-void print_stack(const char *format, ...);
+void print_log(int level, const char* format, ...);
+void print_stack(const char* format, ...);
 
 struct bfd_handle;
 
 struct symbol_ent {
   ulong addr;
   string name;
-  operator   ulong() const {
-    return addr;
-  }
-  symbol_ent():addr(0) {
-  }
+  operator ulong() const { return addr; }
+  symbol_ent() : addr(0) {}
 };
 
 struct symbol_table {
-  typedef vector < symbol_ent > symbols_type;
+  typedef vector<symbol_ent> symbols_type;
   symbols_type symbols;
   ulong text_vma;
   ulong text_size;
-  bfd_handle *bh;
-  symbol_table():text_vma(0), text_size(0) {
-  } ~symbol_table() {
-  }
+  bfd_handle* bh;
+  symbol_table() : text_vma(0), text_size(0) {}
+  ~symbol_table() {}
 };
 
 struct auto_fp {
-  explicit auto_fp(FILE * fp):fp(fp) {
-  } ~auto_fp() {
+  explicit auto_fp(FILE* fp) : fp(fp) {}
+  ~auto_fp() {
     if (fp) {
       fclose(fp);
     }
   }
-  operator   FILE *() {
-    return fp;
-  }
-private:
-  FILE * fp;
-  auto_fp(const auto_fp &);
-  auto_fp & operator =(const auto_fp &);
+  operator FILE*() { return fp; }
+
+ private:
+  FILE* fp;
+  auto_fp(const auto_fp&);
+  auto_fp& operator=(const auto_fp&);
 };
 
 struct bfd_handle {
-  bfd_handle(const char *filename):filename(filename) {
+  bfd_handle(const char* filename) : filename(filename) {
     size = 0;
     has_debug_symbols = false;
     syms = NULL;
     st = NULL;
     debug_file = NULL;
-  } void close_all();
-  void init(const char *file);
+  }
+  void close_all();
+  void init(const char* file);
   void debug_init();
   void close();
   void load_symbols(bool relative, ulong addr_begin);
   void load_debug_section_if();
-  bfd *get();
+  bfd* get();
   bool has_debug();
   void free_syms_if();
   void free_st_if();
-  int get_file_line(ulong addr, const char **file, const char **function,
-		    uint * lineno);
+  int get_file_line(ulong addr,
+                    const char** file,
+                    const char** function,
+                    uint* lineno);
 
-  symbol_table *st;
-  const char *filename;
-private:
+  symbol_table* st;
+  const char* filename;
+
+ private:
   uint size;
   bool dynamic;
-  char *debug_file;
-  asection *dbgsec;
+  char* debug_file;
+  asection* dbgsec;
   bool has_debug_symbols;
-  bfd *abfd;
-  asymbol **syms;
+  bfd* abfd;
+  asymbol** syms;
   ulong symcnt;
 };
 
 struct symbol_table_map {
-  symbol_table_map() {
-  } ~symbol_table_map() {
+  symbol_table_map() {}
+  ~symbol_table_map() {
     for (m_type::iterator i = m.begin(); i != m.end(); ++i) {
-      symbol_table *st = i->second;
-      bfd_handle *bh = st->bh;
+      symbol_table* st = i->second;
+      bfd_handle* bh = st->bh;
       bh->close_all();
       delete bh;
     }
   }
-  symbol_table *get(const std::string & path) {
+  symbol_table* get(const std::string& path) {
     m_type::iterator i = m.find(path);
     if (i != m.end()) {
       return i->second;
     }
     return NULL;
   }
-  void set(const std::string & path, symbol_table * st) {
-    m[path] = st;
-  }
-private:
-  typedef map < std::string, symbol_table * >m_type;
-  m_type m;
-private:
-  symbol_table_map(const symbol_table_map &);
-  symbol_table_map & operator =(const symbol_table_map &);
-};
+  void set(const std::string& path, symbol_table* st) { m[path] = st; }
 
+ private:
+  typedef map<std::string, symbol_table*> m_type;
+  m_type m;
+
+ private:
+  symbol_table_map(const symbol_table_map&);
+  symbol_table_map& operator=(const symbol_table_map&);
+};
 
 struct proc_map_ent {
   ulong addr_begin;
   ulong addr_size;
   ulong offset;
   string path;
-  symbol_table *stbl;
-  bool relative:1;
-  bool is_vdso:1;
-  operator   ulong() const {
-    return addr_begin;
-  } /* for comparison */
-      proc_map_ent():addr_begin(0), addr_size(0), offset(0), stbl(0),
-  relative(false), is_vdso(false) {
-  }
+  symbol_table* stbl;
+  bool relative : 1;
+  bool is_vdso : 1;
+  operator ulong() const { return addr_begin; } /* for comparison */
+  proc_map_ent()
+      : addr_begin(0),
+        addr_size(0),
+        offset(0),
+        stbl(0),
+        relative(false),
+        is_vdso(false) {}
 };
 
 struct proc_info {
-  typedef vector < proc_map_ent > maps_type;
+  typedef vector<proc_map_ent> maps_type;
   maps_type maps;
   struct timeval tv_start;
   struct timeval tv_end;
@@ -177,7 +179,7 @@ typedef struct stopper_symbol {
 
 extern int target_pid;
 extern int debug_level;
-extern const char *debug_dir;
+extern const char* debug_dir;
 extern stopper_symbol stopper[];
 extern int num_stopper_symbol;
 extern int print_arg;
@@ -187,7 +189,7 @@ extern int basename_only;
 extern int max_ptrace_calls;
 extern int frame_check;
 extern int debug_print_time_level;
-extern const char *stack_out;
+extern const char* stack_out;
 extern int flush_log;
 extern int timeout_seconds;
 extern bool lock_all;

--- a/quickstack.h
+++ b/quickstack.h
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <iostream>
+#include <fstream>
 #include <dirent.h>
 #include <vector>
 #include <map>
@@ -184,6 +185,32 @@ typedef struct stopper_symbol {
   ulong addr_begin;
   ulong addr_end;
 } stopper_symbol;
+
+typedef struct thread_info {
+  thread_info(const int tid) : tid(tid) {
+    const string file_path = "/proc/" + std::to_string(tid) + "/comm";
+    std::ifstream comm_file(file_path);
+    if (comm_file.is_open()) {
+      std::getline(comm_file, name);
+      comm_file.close();
+    } else {
+      name = "UNKNOWN";
+    }
+  }
+
+  static inline size_t max_name_len() {
+    return 16U;
+  }
+
+  int tid;
+  string name;
+} thread_info;
+
+inline bool operator<(const thread_info& lhs, const thread_info& rhs) {
+  return lhs.tid < rhs.tid;
+}
+
+typedef struct vector<thread_info> thread_list;
 
 extern int target_pid;
 extern int debug_level;


### PR DESCRIPTION
It's basically D2639408, D2645573, D2652510 as is. So it's all tested.

Re clang-format: I had struggled to avoid this not to break annotate but that tabs/spaces mix was messing things up so I ended up with this formatting thing.

Re C++11 & cmake 3.1: IMO they have been in use for quite a long time and should be supported/exist on contemporary platforms.
 