### PR TITLE
Fix ubuntu package name libelf-dev in README

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ How to build:
 
 Install dependencies (Ubuntu):
 sudo apt-get install binutils-dev
-sudo apt-get install elfutils-dev
+sudo apt-get install libelf-dev
 sudo apt-get install libiberty-dev
 
 


### PR DESCRIPTION
Should fix https://github.com/yoshinorim/quickstack/issues/8 