### PR TITLE
Fix inverted message when SIGCONT is taking its sweet time

### DIFF
--- a/quickstack.cc
+++ b/quickstack.cc
@@ -1355,7 +1355,7 @@ int cont_process_if(int pid) {
     sleep(2);
   }
   if (is_stopped) {
-    DBG(1, "Failed to stop pid %d", pid);
+    DBG(1, "Failed to start pid %d", pid);
     return 1;
   }
   return 0;


### PR DESCRIPTION
Previously this said that we failed to *stop*, but this is wrong since
we actually are still waiting for SIGCONT to have an effect.