### PR TITLE
Add support for the aarch64 architecture

### DIFF
--- a/quickstack.h
+++ b/quickstack.h
@@ -5,6 +5,7 @@
 #define PACKAGE_VERSION 1
 
 #include <bfd.h>
+#include <bits/types/struct_iovec.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +17,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#if defined(__x86_64__) || defined(__i386__)
 #include <sys/reg.h>
+#endif
 #include <sys/time.h>
 #include <unistd.h>
 #include <limits.h>


### PR DESCRIPTION
PTRACE_GETREGS is not supported on the aarch64 architecture so I replaced it with PTRACE_GETREGSET.

With the patch I can trace an app on such a machine:

fila@jetson:~/workspace/quickstack$ uname -m; ./quickstack -f -p $(pidof cooder)
aarch64
2021-01-26 11:16:20 251078: Reading process symbols..
2021-01-26 11:16:20 377897: No debug symbols found on /lib/aarch64-linux-gnu/libpthread-2.31.so
2021-01-26 11:16:20 381483: Gathering stack traces..
2021-01-26 11:16:20 399868: Printing stack traces..
2021-01-26 11:16:20 400268: Total Traced Time: 18.014 milliseconds
2021-01-26 11:16:20 400691: Average Traced Time Per LWP:  3.603 milliseconds
2021-01-26 11:16:20 401079: Longest Traced LWP: LWP 54287, 11.253 milliseconds

Thread 5 (LWP 54288):
 .01  0x000000556fc3bdf8 in cooder::vec3f::Vec3f::new () from /home/fila/cooder_src/src/vec3f/mod.rs:91
 .02  0x000000556fdfd368 in std::sys::unix::thread::Thread::new::thread_start () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/liballoc/boxed.rs:1022
 .03  0x0000007f78c234fc in start_thread () from /lib/aarch64-linux-gnu/libpthread-2.31.so

Thread 4 (LWP 54289):
 .01  0x000000556fc3641c in cooder::box_test () from /home/fila/cooder_src/src/main.rs:276
 .02  0x000000556fdfd368 in std::sys::unix::thread::Thread::new::thread_start () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/liballoc/boxed.rs:1022
 .03  0x0000007f78c234fc in start_thread () from /lib/aarch64-linux-gnu/libpthread-2.31.so

Thread 3 (LWP 54290):
 .01  0x000000556fc3be00 in cooder::vec3f::Vec3f::new () from /home/fila/cooder_src/src/vec3f/mod.rs:93
 .02  0x000000556fdfd368 in std::sys::unix::thread::Thread::new::thread_start () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/liballoc/boxed.rs:1022
 .03  0x0000007f78c234fc in start_thread () from /lib/aarch64-linux-gnu/libpthread-2.31.so

Thread 2 (LWP 54291):
 .01  0x000000556fc39cac in std::f32::<impl f32>::abs () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/libstd/f32.rs:172
 .02  0x000000556fdfd368 in std::sys::unix::thread::Thread::new::thread_start () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/liballoc/boxed.rs:1022
 .03  0x0000007f78c234fc in start_thread () from /lib/aarch64-linux-gnu/libpthread-2.31.so

Thread 1 (LWP 54287):
 .01  0x0000007f78c2a01c in pthread_cond_wait@@GLIBC_2.17 () from /lib/aarch64-linux-gnu/libpthread-2.31.so
 .02  0x000000556fdfb5f0 in std::panicking::try::do_call () from /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8//src/libstd/rt.rs:52
 .03  0x000000556fc36e20 in main ()

I've tested also on a x86_64 machine and it kept working:
[fila@some_machine ~/tmp/quickstack] uname -m; sudo  quickstack -f -p `pidof mysqld`
x86_64
2021-01-26 02:37:41 104073: Setting mount namespace failed. Errno: 22
2021-01-26 02:37:41 104167: Target pid: 207919 (inside container: 207919)
2021-01-26 02:37:41 105261: Reading process symbols..
2021-01-26 02:37:41 150484: Gathering stack traces..
2021-01-26 02:37:41 155788: Printing stack traces..
2021-01-26 02:37:41 155801: Total Traced Time:  4.278 milliseconds
2021-01-26 02:37:41 155808: Average Traced Time Per LWP:  0.084 milliseconds
2021-01-26 02:37:41 155812: Longest Traced LWP: LWP 257237,  0.150 milliseconds

Thread 51 (LWP 257237):
 .01  0x0000000000bf8d32 in one_thread_per_connection_end () from /data/sers/arahut/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/include/mysql/psi/mysql_thread.h:1177
 .02  0x0000000000da2318 in do_handle_one_connection () from /data/st/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/sql/sql_connect.cc:1497
 .03  0x0000000000da1d29 in handle_one_connection () from /data/st/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/sql/sql_connect.cc:1279

Thread 50 (LWP 208089):
 .01  0x0000000000bf8d32 in one_thread_per_connection_end () from /data/st/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/include/mysql/psi/mysql_thread.h:1177
 .02  0x0000000000da2318 in do_handle_one_connection () from /data/st/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/sql/sql_connect.cc:1497
 .03  0x0000000000da1d29 in handle_one_connection () from /data/st/mysql-int/5.6/_build-5.6-rpm/BUILD/mysql-5.6.35/sql/sql_connect.cc:1279
...